### PR TITLE
Use local resolver settings instead of google DNS 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 *.dylib
 
 # dnsee binary
-./dnsee
+dnsee
 
 # Test binary, built with `go test -c`
 *.test

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,7 +54,7 @@ var (
 
 func init() {
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
-	rootCmd.Flags().StringVar(&dnsServerIP, "dns-server-ip", "8.8.8.8", "IP address of the DNS server")
+	rootCmd.Flags().StringVar(&dnsServerIP, "dns-server-ip", "", "IP address of the DNS server")
 	rootCmd.Flags().StringVarP(&userSpecifiedQueryType, "query-type", "q", "", "Specific query type to filter on")
 }
 


### PR DESCRIPTION
Use the local DNS settings saved in `/etc/resolv.conf` instead of using `8.8.8.8` when not specifying an ip address from the CLI.

Note, on Windows systems this is not available. In those case you can still use the tool with the `--dns-server-ip flag.`

Closes #1 