### PR TITLE
feat: add GitHub Issue labelling

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -1,0 +1,13 @@
+github-actions:
+- '.github/**'
+- '.goreleaser.yaml'
+
+dependencies: 
+- 'go.mod'
+- 'go.sum'
+
+documentation:
+- 'README.md'
+
+legal:
+- 'LICENSE'

--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -1,0 +1,18 @@
+name: Label issues
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - run: gh issue edit "$NUMBER" --add-label "$LABELS"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          LABELS: needs-triage


### PR DESCRIPTION
## What
* Adds a workflow to label newly created issues with a `needs-triage` label.

## Why
* This helps in raising awareness and reviewing created issues through maintainers of `dnsee`

## References
* Closes #13 
