### PR TITLE
Re-order priority when printing MX records

### DIFF
--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -91,7 +91,7 @@ func DisplayRecords(domainName string, queryType struct {
 			}
 		case dns.TypeMX:
 			if mxRecord, ok := ans.(*dns.MX); ok {
-				fmt.Printf("%s\t%s.\t%d\t%s\t%d\n", color.HiYellowString(queryType.Name), color.HiBlueString(domainName), mxRecord.Hdr.Ttl, mxRecord.Mx, mxRecord.Preference)
+				fmt.Printf("%s\t%s.\t%d\t%d\t%s\n", color.HiYellowString(queryType.Name), color.HiBlueString(domainName), mxRecord.Hdr.Ttl, mxRecord.Preference, mxRecord.Mx)
 			}
 		case dns.TypeTXT:
 			if txtRecord, ok := ans.(*dns.TXT); ok {


### PR DESCRIPTION
## What
* Prints the priority of a MX record on the left side.

## Why
* Makes MX records easier to read.

## References
* Closes #10
