### PR TITLE
feat: create `triage-ci.yaml`

### DIFF
--- a/.github/workflows/triage-ci.yaml
+++ b/.github/workflows/triage-ci.yaml
@@ -1,0 +1,14 @@
+name: "Triage PRs"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v4
+      with:
+        configuration-path: .github/labeler.yaml


### PR DESCRIPTION
## What
* Adds the ability to triage pull requests by adding labels to them.
 
## Why
* Labels create visibility and awareness.

## References
* Closes #12 
