### PR TITLE
Allow passing multiple query types through the `-q` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ $ dnsee google.com -q A
 A       google.com.     146     142.251.39.110
 ```
 
+Multiple types can be passed at once:
+```
+$ dnsee google.com -q 'A SOA'
+A	google.com.	105	142.251.36.46
+SOA	google.com.	20	ns1.google.com.	dns-admin.google.com.
+```
+
 ### Fetch all records using a different DNS server
 
 To get all records for a domain name using a different DNS server:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,15 +40,20 @@ var (
 
 			client := dns.Client{}
 
-			queryTypes := core.GetQueryTypes()
+			supportedQueryTypes := core.GetQueryTypes()
+
+			typesToQuery := supportedQueryTypes
 
 			// If a specific query type is provided, filter the queryTypes slice to only include that type
 			if flagStore.UserSpecifiedQueryType != "" {
-				queryTypes = core.FilterQueryTypes(queryTypes, flagStore.UserSpecifiedQueryType)
+				// Parse the user-specified query type(s) into a slice of query types
+				// Example: "A AAAA" -> []string{"A", "AAAA"}
+				userSpecifiedQueryTypes := strings.Fields(flagStore.UserSpecifiedQueryType)
+				typesToQuery = core.FilterQueryTypes(supportedQueryTypes, userSpecifiedQueryTypes)
 			}
 
 			// Send a DNS query for each query type in the queryTypes slice
-			for _, queryType := range queryTypes {
+			for _, queryType := range typesToQuery {
 				msg := core.PrepareDNSQuery(domainName, queryType.Type)
 
 				response, _, err := core.SendDNSQuery(&client, msg, flagStore.DNSServerIP)
@@ -66,7 +71,7 @@ func init() {
 	setupCobraUsageTemplate()
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
 	rootCmd.Flags().StringVar(&flagStore.DNSServerIP, "dns-server-ip", "", "IP address of the DNS server")
-	rootCmd.Flags().StringVarP(&flagStore.UserSpecifiedQueryType, "query-type", "q", "", "specific query type to filter on")
+	rootCmd.Flags().StringVarP(&flagStore.UserSpecifiedQueryType, "query-type", "q", "", "specific query type(s) to filter on")
 	rootCmd.Flags().BoolVarP(&flagStore.Debug, "debug", "d", false, "verbose logging")
 }
 

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -3,6 +3,7 @@ package core
 import (
 	"fmt"
 	"runtime"
+	"strings"
 	"time"
 
 	model "github.com/bschaatsbergen/dnsee/pkg/model"
@@ -29,13 +30,17 @@ func GetQueryTypes() []model.QueryType {
 }
 
 // FilterQueryTypes filters the queryTypes slice to only include the query type specified by the user.
-func FilterQueryTypes(queryTypes []model.QueryType, userSpecifiedQueryType string) []model.QueryType {
+func FilterQueryTypes(queryTypes []model.QueryType, userSpecifiedQueryTypes []string) []model.QueryType {
 	var filteredQueryTypes []model.QueryType
-	for _, queryType := range queryTypes {
-		if queryType.Name == userSpecifiedQueryType {
-			filteredQueryTypes = append(filteredQueryTypes, queryType)
-			break
+	for _, userSpecifiedQueryType := range userSpecifiedQueryTypes {
+		for _, queryType := range queryTypes {
+			if queryType.Name == strings.ToUpper(userSpecifiedQueryType) {
+				filteredQueryTypes = append(filteredQueryTypes, queryType)
+			}
 		}
+	}
+	if len(filteredQueryTypes) == 0 {
+		logrus.Fatal("error: Invalid or unsupported query type provided.")
 	}
 	return filteredQueryTypes
 }


### PR DESCRIPTION
## What
* Allow passing multiple query types through the `-q` option
* Print an error in case no valid or supported query type is given by the user
* Allow passing query types in lowercase

## Why
* I believe it's valuable for an user to be able to query for multiple specific record types that they're interested in at once.

## References
* N/A
