### PR TITLE
Improve debug logging of DNS queries

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -95,8 +95,10 @@ func (f *PlainFormatter) Format(entry *log.Entry) ([]byte, error) {
 func toggleDebug(cmd *cobra.Command, args []string) {
 	if flagStore.Debug {
 		log.SetLevel(log.DebugLevel)
+		log.SetFormatter(&log.TextFormatter{
+			DisableTimestamp: true,
+		})
 		log.Debug("Debug logs enabled")
-		log.SetFormatter(&log.TextFormatter{})
 	} else {
 		plainFormatter := new(PlainFormatter)
 		log.SetFormatter(plainFormatter)

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -62,7 +62,7 @@ func SendDNSQuery(client *dns.Client, msg dns.Msg, dnsServerIP string) (*dns.Msg
 		dnsServerIP = conf.Servers[0]
 	}
 
-	logrus.Debugf("Sending query to %s", dnsServerIP)
+	logrus.Debugf("Sending DNS query to %s", dnsServerIP)
 	response, timeDuration, err := client.Exchange(&msg, dnsServerIP+":53")
 
 	if err != nil {

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -61,12 +61,17 @@ func SendDNSQuery(client *dns.Client, msg dns.Msg, dnsServerIP string) (*dns.Msg
 		}
 		dnsServerIP = conf.Servers[0]
 	}
-	logrus.Debugf("Sending DNS query to %s", dnsServerIP)
+
+	logrus.Debugf("Sending query to %s", dnsServerIP)
 	response, timeDuration, err := client.Exchange(&msg, dnsServerIP+":53")
+
 	if err != nil {
+		logrus.Debug("Failed to receive DNS response.")
+		logrus.Debugf("Query sent to DNS server:\n%s", msg.String())
 		logrus.Fatal(err)
 	}
 	logrus.Debugf("Received DNS response from %s, Round-trip time: %s", dnsServerIP, timeDuration)
+	logrus.Debugf("Response body:\n%s", response.String())
 	return response, timeDuration, nil
 }
 


### PR DESCRIPTION
## What
* Makes debug logging more useful by printing the DNS query and received response

Example of happy flow:
```
❯ ./dnsee google.com -q A -d
DEBU Debug logs enabled
DEBU Sending query to 1.1.1.1
DEBU Received DNS response from 1.1.1.1, Round-trip time: 48.640625ms
DEBU Response body:
;; opcode: QUERY, status: NOERROR, id: 16245
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0
feat: improve debug logging of dns queries

;; QUESTION SECTION:
;google.com.	IN	 A

;; ANSWER SECTION:
google.com.	203	IN	A	142.251.39.110
A	google.com.	203	142.251.39.110
```

Unhappy flow:
```
❯ ./dnsee google.com -q A -d
DEBU Debug logs enabled
DEBU Sending query to 1.1.1.1
DEBU Failed to receive DNS response.
DEBU Query sent to DNS server:
;; opcode: QUERY, status: NOERROR, id: 22637
;; flags: rd; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 0

;; QUESTION SECTION:
;google.com.	IN	 A
FATA read udp 192.168.2.4:49900->1.1.1.1:53: i/o timeout
```
## Why
* More information available in the debug logs
* Better readability of debug logs

## References
* Closes #9 
