### PR TITLE
Fix not able to query IPv6 DNS servers because of `too many colons in address`

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,7 +51,6 @@ var (
 			for _, queryType := range queryTypes {
 				msg := core.PrepareDNSQuery(domainName, queryType.Type)
 
-				response, _, err := core.SendDNSQuery(&client, msg, flagStore.DNSServerIP)
 				response, _, err := core.SendDNSQuery(&client, msg, flagStore.DNSServerIP, flagStore.DNSServerPort)
 				if err != nil {
 					log.Fatal(err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,6 +52,7 @@ var (
 				msg := core.PrepareDNSQuery(domainName, queryType.Type)
 
 				response, _, err := core.SendDNSQuery(&client, msg, flagStore.DNSServerIP)
+				response, _, err := core.SendDNSQuery(&client, msg, flagStore.DNSServerIP, flagStore.DNSServerPort)
 				if err != nil {
 					log.Fatal(err)
 				}
@@ -66,6 +67,7 @@ func init() {
 	setupCobraUsageTemplate()
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
 	rootCmd.Flags().StringVar(&flagStore.DNSServerIP, "dns-server-ip", "", "IP address of the DNS server")
+	rootCmd.Flags().StringVar(&flagStore.DNSServerPort, "dns-server-port", "53", "port of the DNS server")
 	rootCmd.Flags().StringVarP(&flagStore.UserSpecifiedQueryType, "query-type", "q", "", "specific query type to filter on")
 	rootCmd.Flags().BoolVarP(&flagStore.Debug, "debug", "d", false, "verbose logging")
 }

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -50,6 +50,7 @@ func PrepareDNSQuery(domainName string, queryType uint16) dns.Msg {
 
 // SendDNSQuery sends a DNS query to a given DNS server.
 func SendDNSQuery(client *dns.Client, msg dns.Msg, dnsServerIP string) (*dns.Msg, time.Duration, error) {
+func SendDNSQuery(client *dns.Client, msg dns.Msg, dnsServerIP, dnsServerPort string) (*dns.Msg, time.Duration, error) {
 	if dnsServerIP == "" {
 		goOS := runtime.GOOS
 		if goOS == windows {

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -66,6 +66,7 @@ func SendDNSQuery(client *dns.Client, msg dns.Msg, dnsServerIP, dnsServerPort st
 
 	addr := net.JoinHostPort(dnsServerIP, dnsServerPort)
 
+	logrus.Debugf("Sending DNS query to %s", addr)
 	response, timeDuration, err := client.Exchange(&msg, addr)
 
 	if err != nil {

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"net"
 	"runtime"
 	"time"
 
@@ -60,6 +61,11 @@ func SendDNSQuery(client *dns.Client, msg dns.Msg, dnsServerIP string) (*dns.Msg
 			logrus.Fatal("Please specify a DNS server IP explicitly with the `--dns-server-ip` flag.")
 		}
 		dnsServerIP = conf.Servers[0]
+
+	}
+	// If the server IP is IPv6, wrap it in square brackets to remove ambiguity from port number and address.
+	if net.ParseIP(dnsServerIP).To4() == nil {
+		dnsServerIP = "[" + dnsServerIP + "]"
 	}
 
 	logrus.Debugf("Sending DNS query to %s", dnsServerIP)

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -49,7 +49,6 @@ func PrepareDNSQuery(domainName string, queryType uint16) dns.Msg {
 }
 
 // SendDNSQuery sends a DNS query to a given DNS server.
-func SendDNSQuery(client *dns.Client, msg dns.Msg, dnsServerIP string) (*dns.Msg, time.Duration, error) {
 func SendDNSQuery(client *dns.Client, msg dns.Msg, dnsServerIP, dnsServerPort string) (*dns.Msg, time.Duration, error) {
 	if dnsServerIP == "" {
 		goOS := runtime.GOOS
@@ -64,13 +63,10 @@ func SendDNSQuery(client *dns.Client, msg dns.Msg, dnsServerIP, dnsServerPort st
 		dnsServerIP = conf.Servers[0]
 
 	}
-	// If the server IP is IPv6, wrap it in square brackets to remove ambiguity from port number and address.
-	if net.ParseIP(dnsServerIP).To4() == nil {
-		dnsServerIP = "[" + dnsServerIP + "]"
-	}
 
-	logrus.Debugf("Sending DNS query to %s", dnsServerIP)
-	response, timeDuration, err := client.Exchange(&msg, dnsServerIP+":53")
+	addr := net.JoinHostPort(dnsServerIP, dnsServerPort)
+
+	response, timeDuration, err := client.Exchange(&msg, addr)
 
 	if err != nil {
 		logrus.Debug("Failed to receive DNS response.")

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -61,7 +61,6 @@ func SendDNSQuery(client *dns.Client, msg dns.Msg, dnsServerIP, dnsServerPort st
 			logrus.Fatal("Please specify a DNS server IP explicitly with the `--dns-server-ip` flag.")
 		}
 		dnsServerIP = conf.Servers[0]
-
 	}
 
 	addr := net.JoinHostPort(dnsServerIP, dnsServerPort)

--- a/pkg/model/flagstore.go
+++ b/pkg/model/flagstore.go
@@ -2,6 +2,7 @@ package model
 
 type Flagstore struct {
 	DNSServerIP            string
+	DNSServerPort          string
 	UserSpecifiedQueryType string
 	Debug                  bool
 }


### PR DESCRIPTION
## What
* Adds square brackets to `dnsServerIP` when using IPv6 addresses. 
* Adds the `dns-server-port` flag to let users specify a port other than the default of `53`.

## Why
* The `:53` port specification of the URI creates ambiguity when used in combination with IPv6 addresses. The square bracket notation is used to resolve this.  Refer to  [RFC3986](https://datatracker.ietf.org/doc/html/rfc3986) for more details.

## References
* Fixes #26 
* Closes #31 
