### PR TITLE
chore: Changed GoReleaser --rm-dist to --clean

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -21,6 +21,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
## What
* Changes `--rm-dist` argument to `--clean`

## Why
* `--rm-dist` is deprecated, see https://goreleaser.com/deprecations/#-rm-dist

## References
* https://goreleaser.com/deprecations/#-rm-dist
