### PR TITLE
feat: Include the query type in the DNS query debug log.

### DIFF
--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -65,7 +65,7 @@ func SendDNSQuery(client *dns.Client, msg dns.Msg, dnsServerIP, dnsServerPort st
 
 	addr := net.JoinHostPort(dnsServerIP, dnsServerPort)
 
-	logrus.Debugf("Sending DNS query to %s", addr)
+	logrus.Debugf("Sending DNS query to %s with query type: %s", dnsServerIP, dns.TypeToString[msg.Question[0].Qtype])
 	response, timeDuration, err := client.Exchange(&msg, addr)
 
 	if err != nil {


### PR DESCRIPTION
## What
* Add the query type to the DNS query debug log.

## Why
* Adds specific query types to the DNS query debug log, improving the log's detail for better understanding and troubleshooting of DNS queries.